### PR TITLE
Actualiza ruta de `Faker.csproj` en Dockerfile

### DIFF
--- a/Faker/Dockerfile
+++ b/Faker/Dockerfile
@@ -10,7 +10,7 @@ ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
 # Copiar el archivo .csproj desde su ubicación
-COPY ["Faker.csproj", "./"]
+COPY ["src/Faker.csproj", "./"]
 
 # Restaurar dependencias para todos los proyectos
 RUN dotnet restore "./Faker.csproj"


### PR DESCRIPTION
Se ha actualizado la instrucción `COPY` en el Dockerfile para reflejar la nueva ubicación del archivo `Faker.csproj`. Anteriormente, el archivo se copiaba directamente desde la raíz del proyecto, pero con este cambio, se especifica que el archivo se encuentra dentro del directorio `src`. Esto asegura que el archivo `Faker.csproj` se copie correctamente durante el proceso de construcción de la imagen Docker.